### PR TITLE
Allow VideoComponentUpdater.cs to detect inactive Audio and Video Man…

### DIFF
--- a/Packages/com.texelsaur.video/Editor/VideoComponentUpdater.cs
+++ b/Packages/com.texelsaur.video/Editor/VideoComponentUpdater.cs
@@ -662,7 +662,7 @@ namespace Texel
             if (!videoPlayer)
                 return list;
 
-            VideoManager[] managers = Object.FindObjectsOfType<VideoManager>();
+            VideoManager[] managers = Object.FindObjectsOfType<VideoManager>(true);
             foreach (VideoManager manager in managers)
             {
                 if (manager.videoPlayer == videoPlayer)
@@ -678,7 +678,7 @@ namespace Texel
             if (!videoPlayer)
                 return list;
 
-            AudioManager[] managers = Object.FindObjectsOfType<AudioManager>();
+            AudioManager[] managers = Object.FindObjectsOfType<AudioManager>(true);
             foreach (AudioManager manager in managers)
             {
                 if (manager.videoPlayer == videoPlayer)


### PR DESCRIPTION
…agers

This change fixes a couple of incorrect error reports in the inspector due to failing to account for inactive components/gameObjects.