### PR TITLE
Allow LocalPlayer.cs to detect if the Video Player is Disabled

### DIFF
--- a/Packages/com.texelsaur.video/Runtime/Scripts/LocalPlayer.cs
+++ b/Packages/com.texelsaur.video/Runtime/Scripts/LocalPlayer.cs
@@ -87,8 +87,20 @@ namespace Texel
         {
             if (!videoMux)
             {
-                DebugLog("No video manager set at time of post init, skipping default playback");
-                return;
+                if (!gameObject.activeInHierarchy)
+                {
+                    gameObject.GetComponentInChildren<VideoManager>(true)._EnsureInit();
+                    if (!videoMux)
+                    {
+                        DebugLog("No video manager found at time of post init, skipping default playback");
+                        return;
+                    }
+                }
+                else
+                {
+                    DebugLog("No video manager set at time of post init, skipping default playback");
+                    return;
+                }
             }
 
             _SetScreenFit(defaultScreenFit);


### PR DESCRIPTION
Detects if the gameObject is disabled in Hierarchy and then performs a search for a child Video Manager. If found, _EnsureInit is run.