### PR TITLE
Allow SyncPlayer.cs to detect if the Video Player is disabled

### DIFF
--- a/Packages/com.texelsaur.video/Runtime/Scripts/SyncPlayer.cs
+++ b/Packages/com.texelsaur.video/Runtime/Scripts/SyncPlayer.cs
@@ -214,8 +214,20 @@ namespace Texel
         {
             if (!videoMux)
             {
-                DebugError("No video manager set at time of post init, skipping default playback");
-                return;
+                if (!gameObject.activeInHierarchy)
+                {
+                    gameObject.GetComponentInChildren<VideoManager>(true)._EnsureInit();
+                    if (!videoMux)
+                    {
+                        DebugError("No video manager found at time of post init, skipping default playback");
+                        return;
+                    }
+                }
+                else
+                {
+                    DebugError("No video manager set at time of post init, skipping default playback");
+                    return;
+                }
             }
 
             if (Networking.IsOwner(gameObject))


### PR DESCRIPTION
After detecting that the video player is disabled, performs a search in children for a Video Manager and if found runs _EnsureInit.